### PR TITLE
docs: add usage examples to README for Neuroscience Data Structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,62 @@
-# Neuroscience Data Structure (NDS)
+\# Neuroscience Data Structure (NDS)
 
-The objective of this project is to put together a set of specifications and tools that would allow the standardization of a directory structure containing experimental data recorded with animal models in neuroscience.
-For this, we aim at capitalizing on the success of BIDS for human neuroimaging data, while retaining the specificities of data sets obtained in animal models.
-Such a standardized data structure will facilitate obtaining reproducible research and data sharing following the FAIR principles.
 
-[Note that the name Neuroscience Data Structure and the associated acronym NDS are purely provisonal]
+
+The objective of this project is to put together a set of specifications and tools that would allow the standardization of a directory structure containing experimental data recorded with animal models in neuroscience.  
+
+For this, we aim at capitalizing on the success of BIDS for human neuroimaging data, while retaining the specificities of data sets obtained in animal models.  
+
+Such a standardized data structure will facilitate obtaining reproducible research and data sharing following the FAIR principles.  
+
+\[Note that the name Neuroscience Data Structure and the associated acronym NDS are purely provisional.]
+
+
+
+---
+
+
+
+\## Examples
+
+
+
+Here’s a minimal example of how to organize subject and session data in NDS:
+
+
+
+```json
+
+{
+
+&nbsp; "subject": {
+
+&nbsp;   "id": "sub-001",
+
+&nbsp;   "species": "Mus musculus",
+
+&nbsp;   "age": 12,
+
+&nbsp;   "sex": "F"
+
+&nbsp; },
+
+&nbsp; "session": {
+
+&nbsp;   "id": "ses-001",
+
+&nbsp;   "task": "visual\_stimulus",
+
+&nbsp;   "acquisition": {
+
+&nbsp;     "device": "EEG",
+
+&nbsp;     "channels": 64
+
+&nbsp;   }
+
+&nbsp; }
+
+}
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,42 +1,14 @@
-\# Neuroscience Data Structure (NDS)
-
-
-
-The objective of this project is to put together a set of specifications and tools that would allow the standardization of a directory structure containing experimental data recorded with animal models in neuroscience.  
-
-For this, we aim at capitalizing on the success of BIDS for human neuroimaging data, while retaining the specificities of data sets obtained in animal models.  
-
-Such a standardized data structure will facilitate obtaining reproducible research and data sharing following the FAIR principles.  
-
-\[Note that the name Neuroscience Data Structure and the associated acronym NDS are purely provisional.]
-
-
-
----
-
-
-
-\## Examples
-
-
-
-Here’s a minimal example of how to organize subject and session data in NDS:
-
-
-
-```json
-
 {
 
 &nbsp; "subject": {
 
-&nbsp;   "id": "sub-001",
+&nbsp;   "id": "sub-002",
 
-&nbsp;   "species": "Mus musculus",
+&nbsp;   "species": "Rattus norvegicus",
 
-&nbsp;   "age": 12,
+&nbsp;   "age": 20,
 
-&nbsp;   "sex": "F"
+&nbsp;   "sex": "M"
 
 &nbsp; },
 
@@ -44,13 +16,13 @@ Here’s a minimal example of how to organize subject and session data in NDS:
 
 &nbsp;   "id": "ses-001",
 
-&nbsp;   "task": "visual\_stimulus",
+&nbsp;   "task": "maze\_navigation",
 
 &nbsp;   "acquisition": {
 
-&nbsp;     "device": "EEG",
+&nbsp;     "device": "VideoTracking",
 
-&nbsp;     "channels": 64
+&nbsp;     "frame\_rate": 30          // Frames per second
 
 &nbsp;   }
 


### PR DESCRIPTION
This PR adds usage examples to the README to help users understand how to organize subjects and sessions using the Neuroscience Data Structure (NDS).
Closes #42
